### PR TITLE
Updated image and description format

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,6 +17,12 @@ body {
   width: 50%;
 }
 
+.wiki-info {
+  display: block;
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
   .footer {
     position: absolute;
     bottom: 0;

--- a/assets/javascript/relevant-image.js
+++ b/assets/javascript/relevant-image.js
@@ -13,9 +13,9 @@ $("#searchButton").on("click", function (event) {
   // Check to see if eithr the city or state are blank
   if (newCity == "" || newState == "") {
     // If either are blank, default to...
-    var citySearch = "Raleigh, NC skyline";
+    var citySearch = "Raleigh, NC";
   } else {
-    var citySearch = newCity + ", " + newState + " skyline";
+    var citySearch = newCity + ", " + newState;
   }
 
   // Log the result as a check
@@ -30,7 +30,8 @@ $("#searchButton").on("click", function (event) {
   var callback = 1; // for json response formatting
   var extras = "description, url_c, url_l, url_o";
   var safe_search = 1; // safe
-  var content_type = 1; // photos only
+  var content_type = 7; // all
+  var addedText = ", skyline";
 
   // Create variables for min / max to create a random number of pictures to choose from
   var targetMax = 5;
@@ -40,7 +41,7 @@ $("#searchButton").on("click", function (event) {
   var targetNumber = Math.floor(Math.random() * targetMax) + targetMin;
 
   // Construct a queryURL based on the Flickr parameters
-  var queryURL = "https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=" + api_key + "&text=" + citySearch + "&extras=" + extras + "&page=" + page + "&per_page=" + per_page + "&safe_search=" + safe_search + "&content_type=" + content_type + "&format=" + format + "&nojsoncallback=" + callback;
+  var queryURL = "https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=" + api_key + "&text=" + citySearch + addedText + "&extras=" + extras + "&page=" + page + "&per_page=" + per_page + "&safe_search=" + safe_search + "&content_type=" + content_type + "&format=" + format + "&nojsoncallback=" + callback;
 
   // Log the URL so we have access to it for troubleshooting
   console.log("---------------\nURL: " + queryURL + "\n---------------");
@@ -56,7 +57,7 @@ $("#searchButton").on("click", function (event) {
 
       // Create a an image tag
       var stockImage = $("<img>");
-      stockImage.addClass("stockImage img-responsive img-thumbnail");
+      stockImage.addClass("img-responsive img-thumbnail");
 
       // Set the stock image source to the Flickr result
       stockImage.attr("src", response.photos.photo[targetNumber].url_l);

--- a/assets/javascript/wiki-info.js
+++ b/assets/javascript/wiki-info.js
@@ -1,6 +1,6 @@
 $("#searchButton").on("click", function (event) {
   event.preventDefault();
-  // Empty the image div
+  // Empty the Wikipedia info div
   $(".wiki-info").empty();
 
   // Get the inputs from the city and state textboxes
@@ -38,9 +38,6 @@ $("#searchButton").on("click", function (event) {
       console.log(response);
 
       // Create a div to hold the info
-      // var wikiDiv = $("<div>");
-      // wikiDiv.addClass("wikiInfo");
-
       var wikiText = $("<p>");
 
       // Set a string variable to capture the response text
@@ -53,11 +50,9 @@ $("#searchButton").on("click", function (event) {
       console.log(targetText);
 
       // Insert the info
-      // wikiDiv.html("<p>" + targetText + "</p>");
       wikiText.append(targetText);
 
       // Append the wikiDiv to the image div
-      // $(".stock-image").append(wikiDiv);
       $(".wiki-info").append(wikiText);
     });
 });

--- a/assets/javascript/wiki-info.js
+++ b/assets/javascript/wiki-info.js
@@ -1,7 +1,7 @@
 $("#searchButton").on("click", function (event) {
   event.preventDefault();
   // Empty the image div
-  $(".stock-image").empty();
+  $(".wiki-info").empty();
 
   // Get the inputs from the city and state textboxes
   var newCity = $("#inputCity").val().trim();
@@ -38,8 +38,10 @@ $("#searchButton").on("click", function (event) {
       console.log(response);
 
       // Create a div to hold the info
-      var wikiDiv = $("<div>");
-      wikiDiv.addClass("wikiInfo");
+      // var wikiDiv = $("<div>");
+      // wikiDiv.addClass("wikiInfo");
+
+      var wikiText = $("<p>");
 
       // Set a string variable to capture the response text
       var str = response.query.pages[0].extract;
@@ -51,9 +53,11 @@ $("#searchButton").on("click", function (event) {
       console.log(targetText);
 
       // Insert the info
-      wikiDiv.html("<p>" + targetText + "</p>");
+      // wikiDiv.html("<p>" + targetText + "</p>");
+      wikiText.append(targetText);
 
       // Append the wikiDiv to the image div
-      $(".stock-image").append(wikiDiv);
+      // $(".stock-image").append(wikiDiv);
+      $(".wiki-info").append(wikiText);
     });
 });

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <!-- if we want to go above and beyond, we can add a favicon -->
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
-        integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"
+        crossorigin="anonymous">
 
 
     <!-- Bootstrap Select CSS -->
@@ -64,37 +64,43 @@
                 </form>
             </div>
         </div>
-        <!-- Image -->
-       <div class="row stock-image">
-        
-       </div>
-    </div>    
-    
+        <!-- Image and short Wikipedia description-->
+        <div class="row">
+            <div class="stock-image col-xs-12 col-md-6">
+
+            </div>
+            <div class="wiki-info col-xs-12 col-md-6">
+
+            </div>
+
+        </div>
+    </div>
+
     <div class="container" id="resultsDiv">
 
     </div>
     <div class="container">
-      <div class="card mt-4 w-100 d-none" id="restaurantCard">
-        <div class="card-header bg-primary text-white">
-         <h3 class="card-title">Popular Restaurants</h3>
+        <div class="card mt-4 w-100 d-none" id="restaurantCard">
+            <div class="card-header bg-primary text-white">
+                <h3 class="card-title">Popular Restaurants</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th scope="col">Restaurant Name</th>
+                            <th scope="col">Address</th>
+                            <th scope="col">Cuisine</th>
+                            <th scope="col">Rating</th>
+                            <th scope="col">Price Range</th>
+                        </tr>
+                    </thead>
+                    <tbody id="restaurantTable">
+
+                    </tbody>
+                </table>
+            </div>
         </div>
-        <div class="table-responsive">
-          <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col">Restaurant Name</th>
-                <th scope="col">Address</th>
-                <th scope="col">Cuisine</th>
-                <th scope="col">Rating</th>
-                <th scope="col">Price Range</th>
-              </tr>
-            </thead>
-            <tbody id="restaurantTable">
-              
-            </tbody>
-          </table>
-        </div>
-      </div>
     </div>
     <footer class="footer">
         <div class="container">
@@ -104,10 +110,8 @@
 
     <!-- Optional (Bootstrap) JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-    <script
-    src="https://code.jquery.com/jquery-3.3.1.min.js"
-    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-    crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
         crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T"
@@ -119,17 +123,12 @@
     <script src="https://www.gstatic.com/firebasejs/5.0.4/firebase.js"></script>
 
     <!-- our javascript goes here -->
-    <script 
-    src="assets/javascript/cities.js"></script>    
-    <script 
-    src="assets/javascript/restaurant.js"></script>
-    <script 
-    src="assets/javascript/weather.js"></script>
-    <script 
-    src="assets/javascript/relevant-image.js"></script>
-    <script 
-    src="assets/javascript/wiki-info.js"></script>
-  
+    <script src="assets/javascript/cities.js"></script>
+    <script src="assets/javascript/restaurant.js"></script>
+    <script src="assets/javascript/weather.js"></script>
+    <script src="assets/javascript/relevant-image.js"></script>
+    <script src="assets/javascript/wiki-info.js"></script>
+
 </body>
 
 


### PR DESCRIPTION
### Aligns with Issue #42 

### HTML
Broke the former `stock-image` div into two divs and updated bootstrap column classes to form two columns at laptop sizing and stacked / one column at smaller screen sizes.
````html
<!-- Image and short Wikipedia description-->
<div class="row">
  <div class="stock-image col-xs-12 col-md-6">

  </div>
  <div class="wiki-info col-xs-12 col-md-6">

  </div>
</div>
````
### CSS
Added `wiki-info` class styling to vertically center the text in the block beside the image.
````css
.wiki-info {
  display: block;
  margin-top: auto;
  margin-bottom: auto;
}
````
### JavaScript
#### relevant-image.js
Removed `stockImage` class that was added to the img tag (not being used).
#### wiki-info.js
Changed `$(".stock-image").empty();` to `$(".wiki-info").empty();` since there is now a second column for the Wikipedia info.

Replaced:
````js
// Create a div to hold the info
var wikiDiv = $("<div>");
wikiDiv.addClass("wikiInfo");

// Insert the info
wikiDiv.html("<p>" + targetText + "</p>");

// Append the wikiDiv to the image div
$(".stock-image").append(wikiDiv);
````
...with:
````js
// Create a div to hold the info
var wikiText = $("<p>");

// Insert the info
wikiText.append(targetText);

// Append the wikiDiv to the image div
$(".wiki-info").append(wikiText);
````



