### PR TITLE
Updated Washington, DC data

### DIFF
--- a/assets/javascript/cities-data.js
+++ b/assets/javascript/cities-data.js
@@ -7987,7 +7987,7 @@ var cityArray = [
     "stateShort": "ID"
   },
   {
-    "city": "Washington, D.C.",
+    "city": "Washington",
     "lat": 38.89954938,
     "lon": -77.00941858,
     "pop": 2445216.5,


### PR DESCRIPTION
### Aligns with Issue #70 

### HTML
None

### CSS
None

### JavaScript
Changed `"city": "Washington, D.C.",` to `"city": "Washington",` so that Wikipedia API will have the `city, state` info needed to retrieve a correct response for Washington, DC.  Otherwise, it attempts to retrieve "Washington, D.C., D.C.", which results in a blank Wikipedia entry.